### PR TITLE
Refactor initial values for cluster

### DIFF
--- a/src/app/cluster/duck/actions.ts
+++ b/src/app/cluster/duck/actions.ts
@@ -1,5 +1,6 @@
 import { IAddEditStatus } from '../../common/add_edit_state';
 import { IMigCluster } from '../../../client/resources/conversions';
+import { ICluster } from './types';
 
 export const ClusterActionTypes = {
   UPDATE_CLUSTERS: 'UPDATE_CLUSTERS',
@@ -20,6 +21,7 @@ export const ClusterActionTypes = {
   UPDATE_CLUSTER_REQUEST: 'UPDATE_CLUSTER_REQUEST',
   CLUSTER_POLL_START: 'CLUSTER_POLL_START',
   CLUSTER_POLL_STOP: 'CLUSTER_POLL_STOP',
+  SET_CURRENT_CLUSTER: 'SET_CURRENT_CLUSTER',
 };
 
 const updateClusters = (updatedClusters: IMigCluster[]) => ({
@@ -50,11 +52,6 @@ const removeClusterSuccess = (name) => ({
 const removeClusterFailure = (err) => ({
   type: ClusterActionTypes.REMOVE_CLUSTER_FAILURE,
   err,
-});
-
-const updateClusterSuccess = (updatedCluster: IMigCluster) => ({
-  type: ClusterActionTypes.UPDATE_CLUSTER_SUCCESS,
-  updatedCluster,
 });
 
 const updateSearchTerm = (searchTerm) => ({
@@ -108,6 +105,13 @@ const stopClusterPolling = () => ({
   type: ClusterActionTypes.CLUSTER_POLL_STOP,
 });
 
+const setCurrentCluster = (currentCluster: ICluster) => {
+  return {
+    type: ClusterActionTypes.SET_CURRENT_CLUSTER,
+    currentCluster,
+  };
+};
+
 export const ClusterActions = {
   updateClusters,
   addClusterSuccess,
@@ -115,7 +119,6 @@ export const ClusterActions = {
   removeClusterRequest,
   removeClusterSuccess,
   removeClusterFailure,
-  updateClusterSuccess,
   updateSearchTerm,
   setClusterAddEditStatus,
   watchClusterAddEditStatus,
@@ -127,4 +130,5 @@ export const ClusterActions = {
   updateClusterRequest,
   startClusterPolling,
   stopClusterPolling,
+  setCurrentCluster,
 };

--- a/src/app/cluster/duck/reducers.ts
+++ b/src/app/cluster/duck/reducers.ts
@@ -14,11 +14,13 @@ export interface IClusterReducerState {
   clusterList: ICluster[];
   searchTerm: string;
   addEditStatus: IAddEditStatus;
+  currentCluster: ICluster;
 }
 
 type ClusterReducerFn = (state: IClusterReducerState, action: any) => IClusterReducerState;
 
 export const INITIAL_STATE: IClusterReducerState = {
+  currentCluster: null,
   isFetchingInitialClusters: true,
   isPolling: false,
   isError: false,

--- a/src/app/cluster/duck/reducers.ts
+++ b/src/app/cluster/duck/reducers.ts
@@ -67,18 +67,6 @@ export const updateClusterRequest: ClusterReducerFn = (state = INITIAL_STATE, ac
   };
 };
 
-export const updateClusterSuccess: ClusterReducerFn = (state = INITIAL_STATE, action) => {
-  return {
-    ...state,
-    clusterList: [
-      ...state.clusterList.filter(
-        (s) => s.MigCluster.metadata.name !== action.updatedCluster.MigCluster.metadata.name
-      ),
-      { ...action.updatedCluster },
-    ],
-  };
-};
-
 export const updateClusters: ClusterReducerFn = (state = INITIAL_STATE, action) => {
   return {
     ...state,
@@ -124,8 +112,6 @@ export const clusterReducer: ClusterReducerFn = (state = INITIAL_STATE, action) 
       return addClusterSuccess(state, action);
     case ClusterActionTypes.UPDATE_CLUSTERS:
       return updateClusters(state, action);
-    case ClusterActionTypes.UPDATE_CLUSTER_SUCCESS:
-      return updateClusterSuccess(state, action);
     case ClusterActionTypes.REMOVE_CLUSTER_SUCCESS:
       return removeClusterSuccess(state, action);
     case ClusterActionTypes.CLUSTER_POLL_START:

--- a/src/app/cluster/duck/reducers.ts
+++ b/src/app/cluster/duck/reducers.ts
@@ -30,6 +30,13 @@ export const INITIAL_STATE: IClusterReducerState = {
   addEditStatus: defaultAddEditStatus(),
 };
 
+export const setCurrentCluster: ClusterReducerFn = (state = INITIAL_STATE, action) => {
+  return {
+    ...state,
+    currentCluster: action.currentCluster,
+  };
+};
+
 export const clusterFetchSuccess: ClusterReducerFn = (state = INITIAL_STATE, action) => {
   return { ...state, clusterList: action.clusterList, isFetching: false };
 };
@@ -100,6 +107,8 @@ export const stopClusterPolling: ClusterReducerFn = (state = INITIAL_STATE, acti
 
 export const clusterReducer: ClusterReducerFn = (state = INITIAL_STATE, action) => {
   switch (action.type) {
+    case ClusterActionTypes.SET_CURRENT_CLUSTER:
+      return setCurrentCluster(state, action);
     case ClusterActionTypes.ADD_CLUSTER_REQUEST:
       return addClusterRequest(state, action);
     case ClusterActionTypes.SET_CLUSTER_ADD_EDIT_STATUS:

--- a/src/app/cluster/duck/sagas.ts
+++ b/src/app/cluster/duck/sagas.ts
@@ -259,6 +259,7 @@ function* addClusterRequest(action) {
     }, {});
 
     yield put(ClusterActions.addClusterSuccess(cluster));
+    yield put(ClusterActions.setCurrentCluster(cluster));
 
     // Push into watching state
     yield put(
@@ -285,9 +286,23 @@ function* updateClusterRequest(action) {
   const { clusterValues } = action;
   const client: IClusterClient = ClientFactory.cluster(state);
 
-  const currentCluster = state.cluster.clusterList.find((c) => {
-    return c.MigCluster.metadata.name === clusterValues.name;
-  });
+  // const currentCluster = state.cluster.clusterList.find((c) => {
+  //   return c.MigCluster.metadata.name === clusterValues.name;
+  // });
+  const migClusterResource = new MigResource(MigResourceKind.MigCluster, migMeta.namespace);
+  const getClusterRes = yield client.get(migClusterResource, clusterValues.name);
+  const secretResource = new CoreNamespacedResource(
+    CoreNamespacedResourceKind.Secret,
+    migMeta.configNamespace
+  );
+  const updatedMigClusterSecretResult = yield client.get(
+    secretResource,
+    getClusterRes.data.spec.secretRef.name
+  );
+  const currentCluster = {
+    MigCluster: getClusterRes.data,
+    Secret: updatedMigClusterSecretResult.data,
+  };
 
   const currentUrl = currentCluster.MigCluster.spec.url;
   const urlUpdated = clusterValues.url !== currentUrl;
@@ -378,7 +393,8 @@ function* updateClusterRequest(action) {
 
     // Update the state tree with the updated cluster, and start to watch
     // again to check for its condition after edits
-    yield put(ClusterActions.updateClusterSuccess(updatedCluster));
+    yield put(ClusterActions.setCurrentCluster(updatedCluster));
+
     yield put(
       ClusterActions.setClusterAddEditStatus(
         createAddEditStatus(AddEditState.Watching, AddEditMode.Edit)

--- a/src/app/cluster/duck/sagas.ts
+++ b/src/app/cluster/duck/sagas.ts
@@ -286,9 +286,6 @@ function* updateClusterRequest(action) {
   const { clusterValues } = action;
   const client: IClusterClient = ClientFactory.cluster(state);
 
-  // const currentCluster = state.cluster.clusterList.find((c) => {
-  //   return c.MigCluster.metadata.name === clusterValues.name;
-  // });
   const migClusterResource = new MigResource(MigResourceKind.MigCluster, migMeta.namespace);
   const getClusterRes = yield client.get(migClusterResource, clusterValues.name);
   const secretResource = new CoreNamespacedResource(

--- a/src/app/home/pages/ClustersPage/ClustersPage.tsx
+++ b/src/app/home/pages/ClustersPage/ClustersPage.tsx
@@ -40,6 +40,7 @@ interface IClustersPageBaseProps {
   isAddEditTokenModalOpen: boolean;
   toggleAddEditTokenModal: () => void;
   setAssociatedCluster: (clusterName: string) => void;
+  setCurrentCluster: (currentCluster: ICluster) => void;
 }
 
 const ClustersPageBase: React.FunctionComponent<IClustersPageBaseProps> = ({
@@ -53,6 +54,7 @@ const ClustersPageBase: React.FunctionComponent<IClustersPageBaseProps> = ({
   toggleAddEditTokenModal,
   isAddEditTokenModalOpen,
   setAssociatedCluster,
+  setCurrentCluster,
 }: IClustersPageBaseProps) => {
   const [isAddEditModalOpen, toggleAddEditModal] = useOpenModal(false);
 
@@ -119,6 +121,7 @@ const ClustersPageBase: React.FunctionComponent<IClustersPageBaseProps> = ({
                     toggleAddEditTokenModal={toggleAddEditTokenModal}
                     isAddEditTokenModalOpen={isAddEditTokenModalOpen}
                     setAssociatedCluster={setAssociatedCluster}
+                    setCurrentCluster={setCurrentCluster}
                   />
                 )}
                 <AddEditClusterModal
@@ -158,6 +161,8 @@ const mapDispatchToProps = (dispatch) => ({
   toggleAddEditTokenModal: () => dispatch(TokenActions.toggleAddEditTokenModal()),
   setAssociatedCluster: (associatedCluster: string) =>
     dispatch(TokenActions.setAssociatedCluster(associatedCluster)),
+  setCurrentCluster: (currentCluster: ICluster) =>
+    dispatch(ClusterActions.setCurrentCluster(currentCluster)),
 });
 
 export const ClustersPage = connect(mapStateToProps, mapDispatchToProps)(ClustersPageBase);

--- a/src/app/home/pages/ClustersPage/components/AddEditClusterModal/AddEditClusterForm.tsx
+++ b/src/app/home/pages/ClustersPage/components/AddEditClusterModal/AddEditClusterForm.tsx
@@ -79,7 +79,7 @@ const InnerAddEditClusterForm = (props: IOtherProps & FormikProps<IFormValues>) 
     setFieldTouched,
     setFieldValue,
     handleBlur,
-    onClose,
+    handleClose,
   } = props;
 
   const [isTokenHidden, setIsTokenHidden] = useState(true);
@@ -249,7 +249,7 @@ const InnerAddEditClusterForm = (props: IOtherProps & FormikProps<IFormValues>) 
         >
           Check connection
         </Button>
-        <Button variant="secondary" onClick={onClose}>
+        <Button variant="secondary" onClick={handleClose}>
           Close
         </Button>
       </Flex>
@@ -268,7 +268,7 @@ export interface IFormValues {
 }
 interface IOtherProps {
   onAddEditSubmit: any;
-  onClose: any;
+  handleClose: any;
   addEditStatus: any;
   currentCluster: any;
   checkConnection: (name) => void;

--- a/src/app/home/pages/ClustersPage/components/AddEditClusterModal/index.tsx
+++ b/src/app/home/pages/ClustersPage/components/AddEditClusterModal/index.tsx
@@ -28,6 +28,8 @@ interface IAddEditClusterModal {
   onHandleClose: () => void;
   resetAddEditState: () => void;
   updateCluster: (updatedCluster) => void;
+  currentCluster: ICluster;
+  setCurrentCluster: (currentCluster: ICluster) => void;
 }
 
 const AddEditClusterModal: React.FunctionComponent<IAddEditClusterModal> = ({
@@ -43,6 +45,8 @@ const AddEditClusterModal: React.FunctionComponent<IAddEditClusterModal> = ({
   onHandleClose,
   resetAddEditState,
   updateCluster,
+  currentCluster,
+  setCurrentCluster,
 }: IAddEditClusterModal) => {
   if (!isAdmin) return null;
 
@@ -71,9 +75,9 @@ const AddEditClusterModal: React.FunctionComponent<IAddEditClusterModal> = ({
     }
   });
 
-  const onClose = () => {
-    cancelAddEditWatch();
+  const handleClose = () => {
     resetAddEditState();
+    cancelAddEditWatch();
     setCurrentCluster(null);
     onHandleClose();
     pollingContext.startAllDefaultPolling();
@@ -82,10 +86,16 @@ const AddEditClusterModal: React.FunctionComponent<IAddEditClusterModal> = ({
   const modalTitle = addEditStatus.mode === AddEditMode.Edit ? 'Edit cluster' : 'Add cluster';
 
   return (
-    <Modal isSmall isOpen={isOpen} onClose={onClose} title={modalTitle} className="always-scroll">
+    <Modal
+      isSmall
+      isOpen={isOpen}
+      onClose={handleClose}
+      title={modalTitle}
+      className="always-scroll"
+    >
       <AddEditClusterForm
         onAddEditSubmit={onAddEditSubmit}
-        onClose={onClose}
+        handleClose={handleClose}
         addEditStatus={addEditStatus}
         initialClusterValues={initialClusterValues}
         currentCluster={currentCluster}
@@ -100,6 +110,7 @@ export default connect(
     return {
       addEditStatus: state.cluster.addEditStatus,
       isPolling: state.cluster.isPolling,
+      currentCluster: state.cluster.currentCluster,
       clusterList: state.cluster.clusterList,
       isAdmin: state.auth.isAdmin,
     };
@@ -120,5 +131,7 @@ export default connect(
     resetAddEditState: () => {
       dispatch(ClusterActions.setClusterAddEditStatus(defaultAddEditStatus()));
     },
+    setCurrentCluster: (currentCluster: ICluster) =>
+      dispatch(ClusterActions.setCurrentCluster(currentCluster)),
   })
 )(AddEditClusterModal);

--- a/src/app/home/pages/ClustersPage/components/AddEditClusterModal/index.tsx
+++ b/src/app/home/pages/ClustersPage/components/AddEditClusterModal/index.tsx
@@ -27,20 +27,6 @@ const AddEditClusterModal = ({
   if (!isAdmin) return null;
 
   const pollingContext = useContext(PollingContext);
-  const [currentClusterName, setCurrentClusterName] = useState(
-    initialClusterValues ? initialClusterValues.clusterName : null
-  );
-  useEffect(() => {
-    /* currentClusterName was not gettting set when exiting and re-entering the modal. 
-    Fixed by passing in cluster to modal component to trigger rerender when it changes & set 
-    cluster name inside this useEffect. 
-    
-   */
-    if (initialClusterValues) {
-      setCurrentClusterName(initialClusterValues.clusterName);
-    }
-  });
-
   const onAddEditSubmit = (clusterValues) => {
     switch (addEditStatus.mode) {
       case AddEditMode.Edit: {
@@ -49,7 +35,7 @@ const AddEditClusterModal = ({
       }
       case AddEditMode.Add: {
         props.addCluster(clusterValues);
-        setCurrentClusterName(clusterValues.name);
+        // setCurrentClusterName(clusterValues.name);
         break;
       }
       default: {

--- a/src/app/home/pages/ClustersPage/components/ClusterActionsDropdown.tsx
+++ b/src/app/home/pages/ClustersPage/components/ClusterActionsDropdown.tsx
@@ -17,6 +17,7 @@ interface IClusterActionsDropdownProps {
   toggleAddEditTokenModal: () => void;
   isAddEditTokenModalOpen: boolean;
   setAssociatedCluster: (clusterName: string) => void;
+  setCurrentCluster: (currentCluster: ICluster) => void;
 }
 
 const ClusterActionsDropdown: React.FunctionComponent<IClusterActionsDropdownProps> = ({
@@ -26,6 +27,8 @@ const ClusterActionsDropdown: React.FunctionComponent<IClusterActionsDropdownPro
   toggleAddEditTokenModal,
   isAddEditTokenModalOpen,
   setAssociatedCluster,
+  cluster,
+  setCurrentCluster,
 }: IClusterActionsDropdownProps) => {
   const {
     clusterName,
@@ -54,11 +57,6 @@ const ClusterActionsDropdown: React.FunctionComponent<IClusterActionsDropdownPro
 
   const clusterContext = useContext(ClusterContext);
 
-  const editCluster = () => {
-    clusterContext.watchClusterAddEditStatus(clusterName);
-    toggleIsAddEditOpen();
-  };
-
   return (
     <>
       <Dropdown
@@ -86,7 +84,9 @@ const ClusterActionsDropdown: React.FunctionComponent<IClusterActionsDropdownPro
                 <DropdownItem
                   onClick={() => {
                     setKebabIsOpen(false);
-                    editCluster();
+                    clusterContext.watchClusterAddEditStatus(clusterName);
+                    setCurrentCluster(cluster);
+                    toggleIsAddEditOpen();
                   }}
                   isDisabled={isHostCluster}
                   key="editCluster"

--- a/src/app/home/pages/ClustersPage/components/ClustersTable.tsx
+++ b/src/app/home/pages/ClustersPage/components/ClustersTable.tsx
@@ -23,6 +23,7 @@ interface IClustersTableProps {
   isAddEditTokenModalOpen: boolean;
   isAdmin: boolean;
   setAssociatedCluster: (clusterName: string) => void;
+  setCurrentCluster: (currentCluster: ICluster) => void;
 }
 
 const ClustersTable: React.FunctionComponent<IClustersTableProps> = ({
@@ -35,6 +36,7 @@ const ClustersTable: React.FunctionComponent<IClustersTableProps> = ({
   isAddEditTokenModalOpen,
   isAdmin,
   setAssociatedCluster,
+  setCurrentCluster,
 }: IClustersTableProps) => {
   const columns = [
     { title: 'Name', transforms: [sortable] },
@@ -91,6 +93,7 @@ const ClustersTable: React.FunctionComponent<IClustersTableProps> = ({
               toggleAddEditTokenModal={toggleAddEditTokenModal}
               isAddEditTokenModalOpen={isAddEditTokenModalOpen}
               setAssociatedCluster={setAssociatedCluster}
+              setCurrentCluster={setCurrentCluster}
             />
           ),
         },


### PR DESCRIPTION
This PR removes the arbitrary setting on the currently edited cluster within the ui component to the sagas file. Instead of using react state to pull the updated cluster, we use the actual api response to measure our updated values against. This fixes bugs that occur when adding/editing a cluster. 

Refactors proposed changes in #976 